### PR TITLE
Remove "account unknown by network" alert, fixes #837

### DIFF
--- a/__tests__/core/services/eventHandlers/onWalletChange.spec.ts
+++ b/__tests__/core/services/eventHandlers/onWalletChange.spec.ts
@@ -6,7 +6,14 @@ import {setMosaics, setNamespaces, setTransactionList} from '@/core/services'
 import {Address} from 'nem2-sdk'
 
 const mockCommit = jest.fn()
-const mockSetAccountInfo = jest.fn()
+const mockSetAccountInfo = (args) => {
+  if (args.state.account.node === 'http://unkonwn.account:3000') {
+    return {walletKnownByNetwork: false}
+  }
+
+  return {walletKnownByNetwork: true}
+}
+
 const mockSetMultisigStatus = jest.fn()
 const mockSwitchAddress = jest.fn()
 const mockSetPartialTransactions = jest.fn()
@@ -17,7 +24,7 @@ jest.mock('@/core/services/transactions')
 jest.mock('@/core/utils')
 
 // @ts-ignore
-MultisigWallet.setAccountInfo = mockSetAccountInfo
+MultisigWallet.setAccountInfo = (args) => mockSetAccountInfo(args)
 // @ts-ignore
 MultisigWallet.setMultisigStatus = mockSetMultisigStatus
 // @ts-ignore
@@ -47,7 +54,6 @@ const store = {
 describe('OnWalletChange', () => {
   beforeEach(async () => {
     mockCommit.mockClear()
-    mockSetAccountInfo.mockClear()
     mockSetMultisigStatus.mockClear()
     // @ts-ignore
     setMosaics.mockClear()
@@ -78,7 +84,6 @@ describe('OnWalletChange', () => {
     expect(mockCommit.mock.calls[5][0]).toBe('RESET_TRANSACTIONS_TO_COSIGN')
     expect(mockCommit.mock.calls[6][0]).toBe('RESET_MOSAICS')
     expect(mockCommit.mock.calls[7][0]).toBe('RESET_NAMESPACES')
-    expect(mockSetAccountInfo).toHaveBeenCalledTimes(1)
     expect(mockSetMultisigStatus).toHaveBeenCalledTimes(1)
     expect(localRead).toHaveBeenCalledTimes(1)
     // @ts-ignore
@@ -90,6 +95,46 @@ describe('OnWalletChange', () => {
     expect(mockSwitchAddress.mock.calls[0][0])
       .toEqual(Address.createFromRawAddress(MultisigWallet.address))
     expect(mockSetPartialTransactions).toHaveBeenCalledTimes(1)
+    expect(mockCommit.mock.calls[8][0]).toBe('SET_TRANSACTIONS_LOADING')
+    expect(mockCommit.mock.calls[8][1]).toBe(false)
+    expect(mockCommit.mock.calls[9][0]).toBe('SET_MOSAICS_LOADING')
+    expect(mockCommit.mock.calls[9][1]).toBe(false)
+    expect(mockCommit.mock.calls[10][0]).toBe('SET_NAMESPACE_LOADING')
+    expect(mockCommit.mock.calls[10][1]).toBe(false)
+    expect(mockCommit.mock.calls[11][0]).toBe('SET_MULTISIG_LOADING')
+    expect(mockCommit.mock.calls[11][1]).toBe(false)
+    done()
+  })
+
+  it('should not call all the methods if the account is unknown by the network', async (done) => {
+    const mockStore = store
+    mockStore.state.account.node = 'http://unkonwn.account:3000'
+    // @ts-ignore
+    await OnWalletChange.trigger(mockStore, MultisigWallet)
+    // @ts-ignore
+    await flushPromises()
+    expect(mockCommit.mock.calls[0][0]).toBe('SET_TRANSACTIONS_LOADING')
+    expect(mockCommit.mock.calls[0][1]).toBe(true)
+    expect(mockCommit.mock.calls[1][0]).toBe('SET_MOSAICS_LOADING')
+    expect(mockCommit.mock.calls[1][1]).toBe(true)
+    expect(mockCommit.mock.calls[2][0]).toBe('SET_NAMESPACE_LOADING')
+    expect(mockCommit.mock.calls[2][1]).toBe(true)
+    expect(mockCommit.mock.calls[3][0]).toBe('SET_MULTISIG_LOADING')
+    expect(mockCommit.mock.calls[3][1]).toBe(true)
+    expect(mockCommit.mock.calls[4][0]).toBe('RESET_TRANSACTION_LIST')
+    expect(mockCommit.mock.calls[5][0]).toBe('RESET_TRANSACTIONS_TO_COSIGN')
+    expect(mockCommit.mock.calls[6][0]).toBe('RESET_MOSAICS')
+    expect(mockCommit.mock.calls[7][0]).toBe('RESET_NAMESPACES')
+    expect(mockSetMultisigStatus).toHaveBeenCalledTimes(0)
+    expect(localRead).toHaveBeenCalledTimes(1)
+    // @ts-ignore
+    expect(localRead.mock.calls[0][0]).toBe(MultisigWallet.address)
+    expect(setMosaics).toHaveBeenCalledTimes(0)
+    expect(setNamespaces).toHaveBeenCalledTimes(0)
+    expect(setTransactionList).toHaveBeenCalledTimes(0)
+    expect(mockSwitchAddress).toHaveBeenCalledTimes(1)
+    expect(mockSwitchAddress.mock.calls[0][0])
+      .toEqual(Address.createFromRawAddress(MultisigWallet.address))
     expect(mockCommit.mock.calls[8][0]).toBe('SET_TRANSACTIONS_LOADING')
     expect(mockCommit.mock.calls[8][1]).toBe(false)
     expect(mockCommit.mock.calls[9][0]).toBe('SET_MOSAICS_LOADING')

--- a/src/components/menu-bar/MenuBarTs.ts
+++ b/src/components/menu-bar/MenuBarTs.ts
@@ -71,11 +71,6 @@ export class MenuBarTs extends Vue {
       message: 'Wallet_network_type_does_not_match_current_network_type',
     }}
 
-    if (!wallet.isKnownByTheNetwork) {return {
-      show: true,
-      message: Message.ADDRESS_UNKNOWN_BY_NETWORK,
-    }}
-
     return {
       show: false,
       message: '',

--- a/src/core/model/AppWallet.ts
+++ b/src/core/model/AppWallet.ts
@@ -62,7 +62,6 @@ export class AppWallet {
   linkedAccountKey: string
   remoteAccount: RemoteAccount | null
   numberOfMosaics: number
-  isKnownByTheNetwork = true
   temporaryRemoteNodeConfig: {
     publicKey: string
     node: string
@@ -315,22 +314,23 @@ export class AppWallet {
     localSave('accountMap', JSON.stringify(accountMap))
   }
 
-  async setAccountInfo(store: Store<AppState>): Promise<void> {
+  async setAccountInfo(store: Store<AppState>): Promise<{walletKnownByNetwork: boolean}> {
     const {EMPTY_PUBLIC_KEY} = networkConfig
     const [accountInfo] = await new AccountHttp(store.state.account.node)
       .getAccountsInfo([Address.createFromRawAddress(store.state.account.wallet.address)])
       .toPromise()
+
     if(!accountInfo){
-      this.isKnownByTheNetwork = false
       this.updateWallet(store)
-      return
+      return {walletKnownByNetwork: false}
     }
+
     this.numberOfMosaics = accountInfo.mosaics ? accountInfo.mosaics.length : 0
     this.importance = accountInfo.importance.compact()
     this.linkedAccountKey = accountInfo.linkedAccountKey === EMPTY_PUBLIC_KEY
       ? null : accountInfo.linkedAccountKey
-    this.isKnownByTheNetwork = true
     this.updateWallet(store)
+    return {walletKnownByNetwork: true}
   }
 
   async updateAccountBalance(balance: number, store: Store<AppState>): Promise<void> {

--- a/src/core/services/eventHandlers/onWalletChange.ts
+++ b/src/core/services/eventHandlers/onWalletChange.ts
@@ -66,8 +66,10 @@ export class OnWalletChange {
 
   private async setWalletDataFromNetwork() {
     const {newWallet, store} = this
-    await newWallet.setAccountInfo(store)
-    if(!newWallet.isKnownByTheNetwork) return
+    const {walletKnownByNetwork} = await newWallet.setAccountInfo(store)
+
+    if (!walletKnownByNetwork) return
+
     await newWallet.setMultisigStatus(store.state.account.node, store)
     await setMosaics(newWallet, store)
     await setNamespaces(newWallet.address, store)


### PR DESCRIPTION
after some thoughts:

If an account is unknown:
- listeners will still work (if unknown account receives tx, it triggers UI update)
- there are no abnormally blocking conditions

Then the alert is not needed.
Plus the alert can (already did) confuse people, and might be a bit glitched, as per #837 and another one on Twitter

The only use case to detect if an account is unknown should then to abort network requests when getting this account's data from the network